### PR TITLE
Add prefetch, overridable keys, & improve typing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -126,7 +126,7 @@ export const useCustomMutation = (
   return [result.mutate, { loading: result.isLoading, ...result }]
 }
 
-export const ReactQueryProvider = ({
+export const RedwoodReactQueryProvider = ({
   children,
 }: {
   children: React.ReactNode

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react'
-import { FetchConfigProvider, GraphQLHooksProvider } from '@redwoodjs/web'
-import { useMutation, UseMutationOptions, useQuery, UseQueryOptions } from 'react-query'
-import { useFetchConfig } from '@redwoodjs/web'
-import { GraphQLClient } from 'graphql-request'
-import { DocumentNode, getOperationAST } from 'graphql'
-import { Variables } from 'graphql-request/dist/types'
-import { GraphQLHookOptions } from '@redwoodjs/web/dist/components/GraphQLHooksProvider'
 import { useAuth } from '@redwoodjs/auth'
+import { FetchConfigProvider, GraphQLHooksProvider } from '@redwoodjs/web'
+import { useFetchConfig } from '@redwoodjs/web'
+import { DocumentNode, getOperationAST } from 'graphql'
+import { GraphQLClient } from 'graphql-request'
+import { Variables } from 'graphql-request/dist/types'
+import {
+  useMutation,
+  UseMutationOptions,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from 'react-query'
 
-type UseCustomQueryOptions = GraphQLHookOptions & UseQueryOptions
+// Export these in case user wants to statically type e.g. a `beforeQuery`
+export type UseCustomQueryOptions = GraphQLQueryHookOptions &
+  UseQueryOptions<unknown, unknown, Variables>
+export type UseCustomMutationOptions = GraphQLMutationHookOptions &
+  UseMutationOptions<unknown, unknown, Variables>
 
 const useGraphqlClient = () => {
   const { uri } = useFetchConfig()
@@ -16,30 +25,60 @@ const useGraphqlClient = () => {
   return graphqlClient
 }
 
-export const useCustomQuery = (query: DocumentNode, { variables, ...options }: UseCustomQueryOptions) => {
-  const { isAuthenticated, getToken, type } = useAuth()
+/**
+ * Builds a query key for the given GraphQL query & variables.
+ * Use when you want to access a query made by a cell.
+ *
+ * **Example**
+ * ```ts
+ * const QUERY = gql`...`
+ * ...
+ * const queryClient = useQueryClient()
+ * queryClient.invalidateQuery(buildQueryKey(QUERY))
+ * ```
+ */
+export const buildQueryKey = (
+  query: DocumentNode,
+  variables: Record<string, unknown>
+) => {
   const document = getOperationAST(query)
   const name = document?.name?.value
+  return [name, variables]
+}
+
+/** Returns a function which makes the given GraphQL request when invoked. */
+export const useClientRequest = <T extends unknown = unknown>(
+  query: DocumentNode,
+  variables: Record<string, unknown>
+) => {
+  const { isAuthenticated, getToken, type } = useAuth()
   const graphqlClient = useGraphqlClient()
 
-  const result = useQuery(
-    [name, variables],
-    async () => {
-      let requestHeaders: HeadersInit = {}
+  return async () => {
+    let requestHeaders: HeadersInit = {}
 
-      if (isAuthenticated) {
-        const token = await getToken()
+    if (isAuthenticated) {
+      const token = await getToken()
 
-        requestHeaders = {
-          'auth-provider': type,
-          authorization: `Bearer ${token}`,
-        }
+      requestHeaders = {
+        'auth-provider': type,
+        authorization: `Bearer ${token}`,
       }
+    }
 
-      return graphqlClient.request(query, variables, requestHeaders)
-    },
-    options
-  )
+    return graphqlClient.request<T>(query, variables, requestHeaders)
+  }
+}
+
+export const useCustomQuery = (
+  query: DocumentNode,
+  options?: UseCustomQueryOptions
+) => {
+  const { variables = {}, queryKey, ...rest } = options ?? {}
+  const key = queryKey ?? buildQueryKey(query, variables)
+  const clientRequest = useClientRequest(query, variables)
+
+  const result = useQuery(key, clientRequest, rest)
 
   return {
     loading: result.isLoading,
@@ -48,13 +87,28 @@ export const useCustomQuery = (query: DocumentNode, { variables, ...options }: U
   }
 }
 
-export const useCustomMutation = (query: DocumentNode, options: UseMutationOptions) => {
+export const usePrefetchQuery = (
+  query: DocumentNode,
+  options?: UseCustomQueryOptions
+) => {
+  const { variables = {}, queryKey, ...rest } = options ?? {}
+  const key = queryKey ?? buildQueryKey(query, variables)
+  const clientRequest = useClientRequest(query, variables)
+
+  const queryClient = useQueryClient()
+
+  return (opts?: UseCustomQueryOptions) =>
+    queryClient.prefetchQuery(key, clientRequest, { ...rest, ...opts })
+}
+
+export const useCustomMutation = (
+  query: DocumentNode,
+  options?: UseCustomMutationOptions
+) => {
   const { isAuthenticated, getToken, type } = useAuth()
   const graphqlClient = useGraphqlClient()
 
-  // TODO: Fix types here
-  // @ts-ignore
-  const result = useMutation(async ({ variables }: { variables: Variables }) => {
+  const result = useMutation(async (variables) => {
     let requestHeaders: HeadersInit = {}
 
     if (isAuthenticated) {
@@ -72,10 +126,17 @@ export const useCustomMutation = (query: DocumentNode, options: UseMutationOptio
   return [result.mutate, { loading: result.isLoading, ...result }]
 }
 
-export function RedwoodReactQueryProvider({ children }: { children: React.ReactNode }) {
+export const ReactQueryProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
   return (
     <FetchConfigProvider>
-      <GraphQLHooksProvider useQuery={useCustomQuery as any} useMutation={useCustomMutation as any}>
+      <GraphQLHooksProvider
+        useQuery={useCustomQuery}
+        useMutation={useCustomMutation}
+      >
         {children}
       </GraphQLHooksProvider>
     </FetchConfigProvider>


### PR DESCRIPTION
I found the need to prefetch and invalidate some of my Cell queries, and also found it useful to override the keys that are generated as well.
Also exported the UseCustom(Query|Mutation)Options for better type support when returning from a `beforeQuery`.
Also fixed up the typing for useMutation (mostly, see gotcha below).

### Example
Invalidating a cell query, prefetching another query, and using custom query keys:
```ts
const CELL_QUERY_KEY = 'my_first_query_key'
const ANOTHER_QUERY_KEY = 'some_other_query_key'

export const beforeQuery = (): UseCustomQueryOptions => ({
  queryKey: CELL_QUERY,
  staleTime: 10 * 60 * 1000,
})

export const QUERY = gql`...`
export const ANOTHER_QUER = gql``
...
  // inside your component function
  // const key = buildQueryKey(QUERY) // This would've been the query key for our cell query if we didn't override it above
  const prefetchQuery = usePrefetchQuery(ANOTHER_QUERY, { queryKey: ANOTHER_QUERY_KEY })
  queryClient.invalidateQueries(CELL_QUERY_KEY) // Probably want to do this in a callback fn/useEffect
```

2 gotchas that I don't have time to resolve:
1. I'm not sure how to get a Cell's `Variables` for use in `buildQueryKey`. Seems like Redwood doesn't forward them along, so I'm using the overridable query key inside a `beforeRequest` instead.
2. Currently I added this to an ambient `index.d.ts` so that I could have my custom query option types everywhere and to also resolve some type errors I was getting with useMutation:
```ts
import { DocumentNode } from 'graphql'
import { ClientError } from 'graphql-request'
import { Variables } from 'graphql-request/dist/types'
import {
  UseMutateFunction,
  UseMutationOptions,
  UseMutationResult,
  UseQueryOptions,
} from 'react-query'

declare module '@redwoodjs/web' {
  export type UseCustomQueryOptions = GraphQLQueryHookOptions &
    UseQueryOptions<unknown, unknown, Variables>
  export type UseCustomMutationOptions = GraphQLMutationHookOptions &
    UseMutationOptions<unknown, unknown, Variables>

  type MutationOperationResult<
    TData = unknown,
    TError = unknown,
    TVariables = unknown
  > = [
    UseMutateFunction<TData, TError, TVariables>,
    UseMutationResult<TData, TError, TVariables> & {
      loading: UseMutationResult<TData, TError, TVariables>['isLoading']
    }
  ]

  function useQuery<TData = unknown, TOptions = UseCustomQueryOptions>(
    query: DocumentNode,
    options?: TOptions
  ): QueryOperationResult<TData>

  function useMutation<TData = unknown, TOptions = UseCustomMutationOptions>(
    mutation: DocumentNode,
    options?: TOptions
  ): MutationOperationResult<TData, ClientError, Variables>
}